### PR TITLE
feat: Disable org.gradle.parallel property due to deadlock problems

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,10 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 
 # Build Performance settings
-org.gradle.parallel=true
+# Property org.gradle.parallel is disabled because of the following issues
+# https://github.com/gradle/gradle/issues/17812
+# https://youtrack.jetbrains.com/issue/KT-47853
+#org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.caching= true
 


### PR DESCRIPTION
Signed-off-by: Igor Duquia Giumelli <igor.giumelli@zup.com.br>

### Related Issues

https://github.com/gradle/gradle/issues/18128
https://github.com/gradle/gradle/issues/17812
https://youtrack.jetbrains.com/issue/KT-47853

### Description and Example

There are know issues with parallelism on Gradle. Locally we are experiencing deadlock problems. See related issues.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
