### PR TITLE
feat: GridView.itemAspectRatio (Flutter)

### DIFF
--- a/framework/src/main/kotlin/br/com/zup/beagle/widget/ui/GridView.kt
+++ b/framework/src/main/kotlin/br/com/zup/beagle/widget/ui/GridView.kt
@@ -38,6 +38,9 @@ import br.com.zup.beagle.widget.ui.GridViewDirection.VERTICAL
  * used as a suffix in the component ids within the Widget.
  * @param spanCount The number of columns or rows in the grid.
  * @param direction define the grid direction.
+ * @param itemAspectRatio only valid for Flutter. This sets the aspect ratio of the items in the grid. If left in
+ * blank, the items will be squares (itemAspectRatio = 1). The Flutter GridView doesn't accept items with arbitrary
+ * size.
  */
 data class GridView constructor(
     override val context: Context? = null,
@@ -51,6 +54,7 @@ data class GridView constructor(
     val key: String? = null,
     val spanCount: Int? = null,
     val direction: GridViewDirection? = VERTICAL,
+    val itemAspectRatio: Double? = null,
 ) : Widget(), ContextComponent
 
 /**


### PR DESCRIPTION
Signed-off-by: Tiago Peres França <tiago.franca@zup.com.br>

### Description and Example

The GridView in Flutter doesn't accept items with arbitrary size, i.e. if the gridview has an item with width and height, this is not used by the gridview to calculate the size of the cell, instead, by default, every item in the gridview is a square. According to the Flutter documentation, we also can't set manually the size of the gridView items, instead, in Flutter, we must use a property called `childAscpectRatio`, which tells the aspect ratio of each cell.

Unfortunately this is incompatible with the current contract of Beagle's GridView. To not mess too much with this contract (which would require changes in all platforms) and also have a usable GridView in Flutter, I exposed `childAscpectRatio` as the Beagle property `itemAspectRatio`. I stated in the API docs that this property is only valid for Flutter.

Docs PR: https://github.com/ZupIT/beagle-docs/pull/838

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
